### PR TITLE
Feature/fix 20

### DIFF
--- a/bark_core/signatures.py
+++ b/bark_core/signatures.py
@@ -322,7 +322,7 @@ class SshKey(Pubkey):
         super().__init__(pubkey)
         parts = pubkey.split()
         self._emails = parts[0].decode().split(",")
-        i = 1
+        i = 0
         while not parts[i] in _SUPPORTED_KEYS:
             i += 1
 

--- a/bark_core/signatures.py
+++ b/bark_core/signatures.py
@@ -352,6 +352,8 @@ class SshKey(Pubkey):
     @classmethod
     def _load_blob(cls, identifier: str) -> bytes:
         try:
+            # expanduser to catch relative paths like ~/.ssh/key.pub
+            identifier = os.path.expanduser(identifier)
             with open(identifier, "rb") as f:
                 pubkey = f.read()
                 return pubkey

--- a/bark_core/signatures.py
+++ b/bark_core/signatures.py
@@ -393,7 +393,7 @@ def get_pubkey_from_git() -> Optional[Pubkey]:
         if gpg_format and gpg_format == "ssh":
             email = cmd("git", "config", "user.email", check=False)[0]
             identifier = os.path.expanduser(identifier) # expand path if relative
-            with open(identifier, 'r') as file: # read public key
+            with open(identifier, 'rb') as file: # read public key
                 pubkey = file.read()
                 return SshKey(f"{email} ".encode() + pubkey.encode())
         return Pubkey.from_identifier(identifier)

--- a/bark_core/signatures.py
+++ b/bark_core/signatures.py
@@ -395,7 +395,7 @@ def get_pubkey_from_git() -> Optional[Pubkey]:
             identifier = os.path.expanduser(identifier) # expand path if relative
             with open(identifier, 'rb') as file: # read public key
                 pubkey = file.read()
-                return SshKey(f"{email} ".encode() + pubkey.encode())
+                return SshKey(f"{email} ".encode() + pubkey)
         return Pubkey.from_identifier(identifier)
     return None
 

--- a/bark_core/signatures.py
+++ b/bark_core/signatures.py
@@ -321,8 +321,8 @@ class SshKey(Pubkey):
     def __init__(self, pubkey: bytes) -> None:
         super().__init__(pubkey)
         parts = pubkey.split()
-        self._emails = parts[2].decode().split(",")
-        i = 0
+        self._emails = parts[0].decode().split(",")
+        i = 1
         while not parts[i] in _SUPPORTED_KEYS:
             i += 1
 
@@ -387,6 +387,17 @@ def get_authorized_pubkeys(
 
 def get_pubkey_from_git() -> Optional[Pubkey]:
     identifier = cmd("git", "config", "user.signingKey", check=False)[0]
+    gpg_format = cmd("git", "config", "gpg.format", check=False)[0]
+    # check if signingKey is ssh
+    if gpg_format and gpg_format == "ssh":
+        email = cmd("git", "config", "user.email", check=False)[0]
+        identifier = os.path.expanduser(identifier) # expand path if relative
+        with open(identifier, 'r') as file: # read public key
+            pubkey = file.read()
+        pubkey_tmp = f"{email} {pubkey}" # join email & pubkey to create correct format
+        identifier = "/tmp/pubkey" # point to tmp dir
+        with open(identifier, "w") as file: # write tmp pubkey with correct format
+            file.write(pubkey_tmp)
     if identifier:
         return Pubkey.from_identifier(identifier)
     return None
@@ -440,6 +451,8 @@ def add_public_keys_interactive() -> None:
             file_name = click_prompt(prompt="Enter the name for the public key")
             _add_public_key_to_repo(p_key, file_name)
             pubkeys.add(p_key)
+            # remove temporary ssh key if exists
+            os.remove("/tmp/pubkey") if os.path.exists("/tmp/pubkey") else None
 
     while True:
         if len(pubkeys) == 0:

--- a/bark_core/signatures.py
+++ b/bark_core/signatures.py
@@ -321,7 +321,7 @@ class SshKey(Pubkey):
     def __init__(self, pubkey: bytes) -> None:
         super().__init__(pubkey)
         parts = pubkey.split()
-        self._emails = parts[0].decode().split(",")
+        self._emails = parts[2].decode().split(",")
         i = 0
         while not parts[i] in _SUPPORTED_KEYS:
             i += 1


### PR DESCRIPTION
Hi,

i debugged this plugin and found 2 errors that lead to #20 .

### 1. Relative Paths

https://github.com/YubicoLabs/gitbark-core/blob/6bb3f2d12747d54c4be1c8bbe65d0b1f74ccd635/bark_core/signatures.py#L355

Since this plugin reads a possible public key from `gitconfig`, this line resulted in an Error:
```
[Errno 2] No such file or directory: '~/.ssh/id_ed25519.pub'
```
To fix this issue I propose to use `os.path.expanduser` to fix this common mistake:

https://github.com/mirisbowring/gitbark-core/blob/d30c7ed2fcd6c0d172f4f7cd7af6433ef3553398/bark_core/signatures.py#L356

### 2. False starting index

During the `__init__` of the `SshKey` you are splitting the read public key to extract the type and the key itself. But during the while iteration you start at 1 instead of 0 which results in an infinite loop until python reaches an out of index since `i > len(parts)` is never catched.

My proposed fix: Start with index 0

https://github.com/mirisbowring/gitbark-core/blob/d30c7ed2fcd6c0d172f4f7cd7af6433ef3553398/bark_core/signatures.py#L325 

### 3. SSH comment interpreted as mail

While testing the `bark verify` i experienced a behaviour, that ssh signatures (though they are valid) are marked as invalid (without a reason). I did a deep dive into the code and discovered the following problem:

https://github.com/YubicoLabs/gitbark-core/blob/6bb3f2d12747d54c4be1c8bbe65d0b1f74ccd635/bark_core/signatures.py#L324

The line above ready the first part of the public key as email which will NEVER work since the first part of the public key is always the keyspec like `ssh_ed25519`. Therefor, the mail Validation in  L342 will always fail:

https://github.com/YubicoLabs/gitbark-core/blob/6bb3f2d12747d54c4be1c8bbe65d0b1f74ccd635/bark_core/signatures.py#L342

To fix this issue, i set the index of the `parts` list to 2 (remember the format: keyspec_pubkey_comment):

https://github.com/mirisbowring/gitbark-core/blob/433326c1f1d256260047afa821fdafd7b731d312/bark_core/signatures.py#L324

> I somehow understand why this check is implemented. Anyway: I strongly recommend to hint this behaviour in the user docs! Since this last part of the public key is specified as comment, there will not always be an email there which will fail every bark verification!